### PR TITLE
feat(config): add MCP initialization config handling and prioritization

### DIFF
--- a/src/shared/utils/config-mcp-init.test.ts
+++ b/src/shared/utils/config-mcp-init.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test } from "@jest/globals";
+import { config } from "./config.util.js";
+
+describe("ConfigLoader MCP Initialization", () => {
+	beforeEach(() => {
+		// Reset the config instance for each test
+		// biome-ignore lint/suspicious/noExplicitAny: Needed for testing private properties
+		(config as any).configLoaded = false;
+		// biome-ignore lint/suspicious/noExplicitAny: Needed for testing private properties
+		(config as any).mcpInitConfig = {};
+
+		// Clear any environment variables that might interfere
+		delete process.env.TEST_KEY;
+		delete process.env.LOKALISE_API_KEY;
+	});
+
+	test("should prioritize MCP init config over environment variables", () => {
+		// Set up environment variable
+		process.env.TEST_KEY = "env_value";
+
+		// Set up MCP init config (should have higher priority)
+		config.setMcpInitConfig({ TEST_KEY: "mcp_value" });
+
+		// Load config from all sources
+		config.load();
+
+		// MCP config should take precedence
+		expect(config.get("TEST_KEY")).toBe("mcp_value");
+	});
+
+	test("should fall back to environment variables when MCP config is not set", () => {
+		// Set up environment variable
+		process.env.TEST_KEY = "env_value";
+
+		// Don't set MCP config for this key
+		config.setMcpInitConfig({});
+
+		// Load config from all sources
+		config.load();
+
+		// Should fall back to environment variable
+		expect(config.get("TEST_KEY")).toBe("env_value");
+	});
+
+	test("should return default value when key is not found in any source", () => {
+		// Don't set the key anywhere
+		config.setMcpInitConfig({});
+		config.load();
+
+		// Should return the default value
+		expect(config.get("NONEXISTENT_KEY", "default_value")).toBe(
+			"default_value",
+		);
+	});
+
+	test("should handle boolean values from MCP config", () => {
+		// Set up MCP init config with boolean-like values
+		config.setMcpInitConfig({
+			BOOL_TRUE: "true",
+			BOOL_FALSE: "false",
+			BOOL_INVALID: "invalid",
+		});
+
+		config.load();
+
+		expect(config.getBoolean("BOOL_TRUE")).toBe(true);
+		expect(config.getBoolean("BOOL_FALSE")).toBe(false);
+		expect(config.getBoolean("BOOL_INVALID")).toBe(false);
+	});
+
+	test("should handle nested config object in MCP init", () => {
+		// Simulate what Smithery might pass
+		const mcpConfig = {
+			LOKALISE_API_KEY: "test_api_key",
+			LOKALISE_API_HOSTNAME: "https://api.example.com/api2/",
+			DEBUG: "true",
+		};
+
+		config.setMcpInitConfig(mcpConfig);
+		config.load();
+
+		expect(config.get("LOKALISE_API_KEY")).toBe("test_api_key");
+		expect(config.get("LOKALISE_API_HOSTNAME")).toBe(
+			"https://api.example.com/api2/",
+		);
+		expect(config.getBoolean("DEBUG")).toBe(true);
+	});
+
+	test("should extract hostname correctly from MCP config", () => {
+		config.setMcpInitConfig({
+			LOKALISE_API_HOSTNAME: "https://api.stage.lokalise.cloud/api2/",
+		});
+
+		config.load();
+
+		expect(config.getLokaliseHostname()).toBe("stage.lokalise.cloud");
+	});
+});


### PR DESCRIPTION
Introduce a handler extracting configuration from MCP client info during initialization, enabling dynamic config setup based on client-provided data.

Update configuration loader to prioritize MCP init config over environment variables and other sources, ensuring runtime flexibility and seamless integration with MCP clients.

Add comprehensive tests verifying MCP config precedence, boolean parsing, nested config handling, and hostname extraction.

Fixes #7