### PR TITLE
feat: add is_plural support for creating plural translation keys

### DIFF
--- a/src/domains/keys/keys.controller.ts
+++ b/src/domains/keys/keys.controller.ts
@@ -118,6 +118,7 @@ async function createKeys(
 			project_id: args.projectId,
 			keys: args.keys.map((key) => ({
 				key_name: key.key_name,
+				is_plural: key.is_plural,
 				description: key.description,
 				platforms: key.platforms,
 				translations: key.translations,

--- a/src/domains/keys/keys.service.ts
+++ b/src/domains/keys/keys.service.ts
@@ -54,11 +54,12 @@ export interface CreateKeysParams {
 	project_id: string;
 	keys: Array<{
 		key_name: string;
+		is_plural?: boolean;
 		description?: string;
 		platforms: SupportedPlatforms[];
 		translations?: Array<{
 			language_iso: string;
-			translation: string;
+			translation: string | Record<string, string>;
 		}>;
 		tags?: string[];
 	}>;
@@ -222,6 +223,7 @@ export async function createKeys(
 		const apiParams = {
 			keys: options.keys.map((key) => ({
 				key_name: key.key_name,
+				is_plural: key.is_plural || false,
 				description: key.description,
 				platforms: key.platforms,
 				translations: key.translations || [],

--- a/src/domains/keys/keys.tool.ts
+++ b/src/domains/keys/keys.tool.ts
@@ -316,7 +316,7 @@ function registerTools(server: McpServer) {
 	// Create Keys Tool
 	server.tool(
 		"lokalise_create_keys",
-		"Adds new UI text or content to be translated (up to 1000 keys per request). Required: projectId, keys array with {key_name, platforms}. Optional per key: description, tags, translations. Use for new features, initial setup, or content expansion. Returns: Created keys with IDs and any errors. Tip: Include base language translations to speed up workflow. Pairs with: lokalise_list_keys to verify.",
+		"Adds new UI text or content to be translated (up to 1000 keys per request). Required: projectId, keys array with {key_name, platforms}. Optional per key: description, is_plural, tags, translations. For plural keys, set is_plural: true and provide translations as objects with CLDR plural categories (e.g. {one: '1 item', other: '%s items', few: '...', many: '...'}). Use for new features, initial setup, or content expansion. Returns: Created keys with IDs and any errors. Tip: Include base language translations to speed up workflow. Pairs with: lokalise_list_keys to verify.",
 		CreateKeysToolArgs.shape,
 		handleCreateKeys,
 	);

--- a/src/domains/keys/keys.types.ts
+++ b/src/domains/keys/keys.types.ts
@@ -53,6 +53,25 @@ export type GetKeyToolArgsType = z.infer<typeof GetKeyToolArgs>;
 /**
  * Zod schema for the create keys tool arguments.
  */
+/**
+ * Zod schema for plural translation forms.
+ * Used when is_plural is true — the translation field accepts an object
+ * with CLDR plural categories instead of a plain string.
+ */
+const PluralFormsSchema = z
+	.object({
+		zero: z.string().optional().describe("Zero form"),
+		one: z.string().optional().describe("Singular form"),
+		two: z.string().optional().describe("Two form"),
+		few: z.string().optional().describe("Few form (e.g. for Polish, Arabic)"),
+		many: z
+			.string()
+			.optional()
+			.describe("Many form (e.g. for Polish, Arabic)"),
+		other: z.string().optional().describe("General plural form"),
+	})
+	.describe("Plural forms object for plural keys");
+
 export const CreateKeysToolArgs = z
 	.object({
 		projectId: z.string().describe("Project ID to create keys in"),
@@ -60,6 +79,12 @@ export const CreateKeysToolArgs = z
 			.array(
 				z.object({
 					key_name: z.string().describe("Name of the key"),
+					is_plural: z
+						.boolean()
+						.optional()
+						.describe(
+							"Whether this key supports plural forms (one/other/few/many/zero)",
+						),
 					description: z
 						.string()
 						.optional()
@@ -72,7 +97,18 @@ export const CreateKeysToolArgs = z
 						.array(
 							z.object({
 								language_iso: z.string().describe("Language ISO code"),
-								translation: z.string().describe("Translation text"),
+								translation: z
+									.union([
+										z
+											.string()
+											.describe(
+												"Translation text for non-plural keys",
+											),
+										PluralFormsSchema,
+									])
+									.describe(
+										"Translation text (string) or plural forms object (with one/other/few/many/zero) for plural keys",
+									),
 							}),
 						)
 						.optional()


### PR DESCRIPTION
## Summary

- Add `is_plural` parameter to `create_keys` tool to support creating plural translation keys
- Accept translations as objects with CLDR plural categories (`zero`/`one`/`two`/`few`/`many`/`other`) instead of only plain strings
- Pass `is_plural` through the full stack: types → controller → service → Lokalise API

## Motivation

Currently there is no way to create a plural key via the MCP tool. The Lokalise REST API supports `is_plural: true` on key creation (see [Lokalise Node API docs](https://github.com/lokalise/node-lokalise-api/blob/master/docs/api/keys.md)), but the MCP tool doesn't expose this parameter. This means users must manually toggle "Set as plural key" in the Lokalise UI after creating keys via MCP.

## Usage example

```json
{
  "projectId": "123456.abcdef",
  "keys": [{
    "key_name": "items.count",
    "is_plural": true,
    "platforms": ["ios", "android", "web"],
    "translations": [
      {
        "language_iso": "en",
        "translation": {
          "one": "%s item",
          "other": "%s items"
        }
      },
      {
        "language_iso": "pl",
        "translation": {
          "one": "%s element",
          "few": "%s elementy",
          "many": "%s elementów",
          "other": "%s elementów"
        }
      }
    ]
  }]
}
```

## Changes

| File | Change |
|------|--------|
| `keys.types.ts` | Added `is_plural` field + `PluralFormsSchema` + union type for `translation` |
| `keys.service.ts` | Pass `is_plural` to Lokalise API + updated `CreateKeysParams` interface |
| `keys.controller.ts` | Map `is_plural` from tool args to service params |
| `keys.tool.ts` | Updated tool description to document plural support |

## Test plan

- [ ] Create a non-plural key (existing behavior unchanged)
- [ ] Create a plural key with `is_plural: true` and object translations
- [ ] Verify plural key appears correctly in Lokalise UI with ONE/OTHER/FEW/MANY forms
- [ ] Verify non-plural keys still accept string translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)